### PR TITLE
Refactor into functions and use docopt for CLI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+/*exclude =*/
+ignore = F401,E226

--- a/README.rst
+++ b/README.rst
@@ -69,10 +69,31 @@ Installing
 Using
 -----
 
-The package provides a command-line interface through the ``gmtmodernize`` command::
+Command line
+++++++++++++
 
-    gmtmodernize OLD_SCRIPTS_FOLDER MODERN_SCRIPTS_FOLDER
+The package provides a command-line interface through the ``gmtmodernize``
+command::
 
-The program will crawl through the ``OLD_SCRIPTS_FOLDER`` and convert any ``.sh`` files
-it finds. The directory structure will be mirrored in ``MODER_SCRIPTS_FOLDER``.
-All other files will be copied to ``MODER_SCRIPTS_FOLDER``.
+    gmtmodernize <classic_scripts> <modern_scripts>
+
+The program will crawl through the ``classic_scripts`` folder and convert any
+``.sh`` files it finds. The directory structure will be mirrored in
+``modern_scripts``.  All other files will be copied to
+``modern_scripts``.
+
+Library
++++++++
+
+Alternatively, you can run the conversion using the ``gmtmodernize`` Python
+library. It exposes a ``modernize`` function that takes a classic script (as a
+single string) and outputs a modern script (also as a single string).
+
+Example::
+
+    from gmtmodernize import modernize
+
+    with open('classic_script.sh') as f:
+        classic = f.read()
+    with open('modern_script.sh') as f:
+        f.write(modernize(classic))

--- a/README.rst
+++ b/README.rst
@@ -95,5 +95,5 @@ Example::
 
     with open('classic_script.sh') as f:
         classic = f.read()
-    with open('modern_script.sh') as f:
+    with open('modern_script.sh', 'w') as f:
         f.write(modernize(classic))

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ This is **work in progress**. So far, it can convert some of the test and
 example scripts from the GMT repository.
 
 
-About
------
+About modern mode
+-----------------
 
 GMT is introducing a "modern" execution mode that reduces the amount of
 arguments needed for many programs and handles the PostScript layer-caking
@@ -73,14 +73,49 @@ Command line
 ++++++++++++
 
 The package provides a command-line interface through the ``gmtmodernize``
-command::
+program::
 
-    gmtmodernize <classic_scripts> <modern_scripts>
+    $ gmtmodernize --help
+    Convert GMT shell scripts from classic to modern mode.
 
-The program will crawl through the ``classic_scripts`` folder and convert any
-``.sh`` files it finds. The directory structure will be mirrored in
-``modern_scripts``.  All other files will be copied to
-``modern_scripts``.
+    Prints the converted modern mode script to standard output (stdout).
+
+    Usage:
+        gmtmodernize SCRIPT
+        gmtmodernize --recursive FOLDER_CLASSIC FOLDER_MODERN
+        gmtmodernize --help
+        gmtmodernize --version
+
+    Arguments:
+        SCRIPT          Classic mode script to convert.
+        FOLDER_CLASSIC  Folder with classic mode scripts (can have multiple
+                        sub-folders).
+        FOLDER_MODERN   Name of output folder with converted modern mode scripts.
+                        Mirrors the folder structure of FOLDER_CLASSIC and copies
+                        all non-script files.
+
+    Options:
+        -r --recursive  Recursively transverse a folder structure with GMT scripts
+                        and other files instead of converting a single file.
+                        Creates a new folder with the same structure and non-script
+                        files copied over, plus the converted GMT scripts.
+        -h --help       Show this help message and exit.
+        --version       Show the version and exit.
+
+    Examples:
+
+        Convert a single GMT script to modern mode:
+
+            $ gmtmodernize classic_script.sh > modern_script.sh
+
+        Convert a folder with GMT scripts, data files, etc, (optionally inside
+        multiple sub-folders):
+
+            $ gmtmodernize -r gmt_classic_scripts/ gmt_modern_scripts/
+
+        This will create a folder 'gmt_modern_scripts' with the same sub-folders
+        and non-script files in 'gmt_classic_scripts' but with the scripts
+        converted to modern mode.
 
 Library
 +++++++

--- a/gmtmodernize/__init__.py
+++ b/gmtmodernize/__init__.py
@@ -3,6 +3,8 @@ Base package for the gmtmodernize program.
 """
 __version__ = '0.1a1'
 
+from .conversion import modernize
+
 
 def test(doctest=True, verbose=True, coverage=False):
     """

--- a/gmtmodernize/conversion.py
+++ b/gmtmodernize/conversion.py
@@ -3,11 +3,41 @@ Functions to convert a classic script into a modern one.
 
 The main functionality is exposed through the ``modernize`` function.
 """
-import os
-import sys
-import shutil
 import re
+import os
 
+
+# List of GMT modules that generate Postscript output
+PS_MODULES = """
+gmtlogo
+grdcontour
+grdimage
+grdvector
+grdview
+psbasemap
+psclip
+pscoast
+pscontour
+pshistogram
+psimage
+pslegend
+psmask
+psrose
+psscale
+pssolar
+pstext
+pswiggle
+psxyz
+psxy
+pscoupe
+psmeca
+pspolar
+pssac
+psvelo
+mgd77track
+pssegyz
+pssegy
+""".split()
 
 
 def modernize(script):
@@ -25,193 +55,66 @@ def modernize(script):
         Script converted to modern mode.
 
     """
-    app = GMTModernizeApp(['bla', 'meh', 'foo'])
-    return '\n'.join(app.modernize(script.split('\n')[:-1]))
+    modern = []
+    ps_name = None
+    psconvert = '\ngmt psconvert -Tp -F$ps\n'
+    script = script.split('\n')[:-1]
 
+    # Copy the header comments and add a command to set the mode
+    # to modern after the header
+    for line in script:
+        line = line.strip()
+        if not line or line[0] != '#':
+            break
+        modern.append(line)
+    last_line = len(modern)
+    modern.append('gmt set GMT_RUNMODE modern')
 
-def warn(*args, **kwargs):
-    """
-    Print message to stderr.
-    """
-    print(file=sys.stderr, *args, **kwargs)
+    # Parse the rest of the script
+    for line in script[last_line:]:
+        line = line.strip()
 
+        # Check if this line defines a .ps file name variable
+        ps_var_def = re.findall(r'^ps=.+\.ps$', line)
+        if ps_var_def:
+            assert len(ps_var_def) == 1, \
+                "Found more than 1 ps variable in line '{}'".format(line)
+            ps_definition = ps_var_def[0]
+            ps_file_name = ps_definition.split('=')[1]
+            ps_name = os.path.splitext(ps_file_name)[0]
+            line = os.path.splitext(ps_definition)[0]
 
-class GMTModernizeApp():
-    """
-    The application class.
-    """
+        # Check if redirecting to the $ps variable and strip it out
+        redirect_to_ps = re.findall(r'.+>+ *\$ps(?: +|$)', line)
+        if redirect_to_ps:
+            assert len(redirect_to_ps) == 1, \
+                "Found more than 1 ps redirection in line '{}'".format(
+                    line)
+            redirection = re.findall(r'>+ *\$ps(?: +|$)', line)[0]
+            line = line.replace(redirection, '').strip()
 
-    # List of GMT modules that generate Postscript output
-    PS_MODULES = """
-    gmtlogo
-    grdcontour
-    grdimage
-    grdvector
-    grdview
-    psbasemap
-    psclip
-    pscoast
-    pscontour
-    pshistogram
-    psimage
-    pslegend
-    psmask
-    psrose
-    psscale
-    pssolar
-    pstext
-    pswiggle
-    psxyz
-    psxy
-    pscoupe
-    psmeca
-    pspolar
-    pssac
-    psvelo
-    mgd77track
-    pssegyz
-    pssegy
-    """.split()
+        # Remove -O -K -R -J
+        okrj = re.findall(r'(?:(?<= )|^)-[KORJ](?: +|$)', line)
+        if okrj:
+            for match in okrj:
+                line = line.replace(match, '')
+            line = line.strip()
 
-    def __init__(self, args, verbose=False, output_type='ps'):
-        self.verbose = verbose
-        assert output_type in ['pdf', 'ps']
-        self.output_type = output_type
-        assert len(args) >= 3, \
-            'Too few arguments. Provide input dir and output dir'
-        self.input_dir = os.path.normpath(args[1])
-        self.output_dir = os.path.normpath(args[2])
-        if '--quite' in args or '-q' in args:
-            self.verbose = False
+        modern.append(line)
+
+        # Check if line is deleting gmt.conf. Need to insert the psconvert
+        # before that.
+
+    # Only add a psconvert call if this script defined a ps variable
+    if ps_name is not None:
+        rm_gmt_conf = [i for i, line in enumerate(modern)
+                       if re.findall('(?:(?<= )|^)rm .* gmt.conf(?: +|$)',
+                                     line)]
+        assert len(rm_gmt_conf) <= 1, "Found more than 1 'rm gmt.conf'"
+        if rm_gmt_conf:
+            modern.insert(rm_gmt_conf[0], psconvert)
+            modern.append('')  # Make sure the file ends in a newline
         else:
-            self.verbose = True
+            modern.append(psconvert)
 
-    def info(self, *args, **kwargs):
-        """
-        Print message to stderr according to set verbosity.
-        """
-        if self.verbose:
-            print(file=sys.stderr, *args, **kwargs)
-
-    def modernize(self, script):
-        """
-        Given a GMT shell script (as a string), modernize it and return the new
-        text.
-        """
-        modern = []
-        ps_name = None
-        if self.output_type == 'ps':
-            args = '-Tp'
-        elif self.output_type == 'pdf':
-            args = '-Tf -P -A'
-        psconvert = '\ngmt psconvert {} -F$ps\n'.format(args)
-
-        # Copy the header comments and add a command to set the mode
-        # to modern after the header
-        for line in script:
-            line = line.strip()
-            if not line or line[0] != '#':
-                break
-            modern.append(line)
-        last_line = len(modern)
-        modern.append('gmt set GMT_RUNMODE modern')
-
-        # Parse the rest of the script
-        for line in script[last_line:]:
-            line = line.strip()
-
-            # Check if this line defines a .ps file name variable
-            ps_var_def = re.findall(r'^ps=.+\.ps$', line)
-            if ps_var_def:
-                assert len(ps_var_def) == 1, \
-                    "Found more than 1 ps variable in line '{}'".format(line)
-                ps_definition = ps_var_def[0]
-                ps_file_name = ps_definition.split('=')[1]
-                ps_name = os.path.splitext(ps_file_name)[0]
-                line = os.path.splitext(ps_definition)[0]
-
-            # Check if redirecting to the $ps variable and strip it out
-            redirect_to_ps = re.findall(r'.+>+ *\$ps(?: +|$)', line)
-            if redirect_to_ps:
-                assert len(redirect_to_ps) == 1, \
-                    "Found more than 1 ps redirection in line '{}'".format(
-                        line)
-                redirection = re.findall(r'>+ *\$ps(?: +|$)', line)[0]
-                line = line.replace(redirection, '').strip()
-
-            # Remove -O -K -R -J
-            okrj = re.findall(r'(?:(?<= )|^)-[KORJ](?: +|$)', line)
-            if okrj:
-                for match in okrj:
-                    line = line.replace(match, '')
-                line = line.strip()
-
-            modern.append(line)
-
-            # Check if line is deleting gmt.conf. Need to insert the psconvert
-            # before that.
-
-        # Only add a psconvert call if this script defined a ps variable
-        if ps_name is not None:
-            rm_gmt_conf = [i for i, line in enumerate(modern)
-                           if re.findall('(?:(?<= )|^)rm .* gmt.conf(?: +|$)',
-                                         line)]
-            assert len(rm_gmt_conf) <= 1, "Found more than 1 'rm gmt.conf'"
-            if rm_gmt_conf:
-                modern.insert(rm_gmt_conf[0], psconvert)
-                modern.append('')  # Make sure the file ends in a newline
-            else:
-                modern.append(psconvert)
-
-        return modern
-
-    def convert_script(self, old_script, modern_script):
-        """
-        Convert a script file in the old style to the modern style.
-
-        Reads in 'old_script', modernize it, and save the output to
-        'modern_scrip'.
-        """
-        self.info('  Converting:', old_script, ' --> ', modern_script)
-        with open(old_script) as infile:
-            old_content = infile.readlines()
-        modern_content = self.modernize(old_content)
-        with open(modern_script, 'w') as outfile:
-            outfile.write('\n'.join(modern_content))
-
-    def crawl_and_modernize(self, input_dir, output_dir):
-        """
-        Crawl the input dir and copy/modernize the contents to output dir.
-
-        Will copy any file that isn't a shell script (ends in .sh).
-        """
-
-        for base, _, files in os.walk(input_dir):
-            self.info('Base dir:', base)
-            base_output = base.replace(input_dir, output_dir)
-            os.mkdir(base_output)
-
-            scripts = set(f for f in files if os.path.splitext(f)[-1] == '.sh')
-            not_scripts = set(files).difference(scripts)
-
-            for file in not_scripts:
-                shutil.copy(os.path.join(base, file), base_output)
-
-            for script in scripts:
-                modern_script = os.path.join(base_output, script)
-                old_script = os.path.join(base, script)
-                self.convert_script(old_script, modern_script)
-
-    def main(self):
-        """
-        Execute the app to convert the scripts.
-        """
-
-        if os.path.exists(self.output_dir):
-            warn("Aborting: Output directory '{}' already exists.".format(
-                self.output_dir))
-            return 1
-
-        self.crawl_and_modernize(self.input_dir, self.output_dir)
-
-        return 0
+    return '\n'.join(modern)

--- a/gmtmodernize/conversion.py
+++ b/gmtmodernize/conversion.py
@@ -1,0 +1,26 @@
+"""
+Functions to convert a classic script into a modern one.
+
+The main functionality is exposed through the ``modernize`` function.
+"""
+
+from .cli import GMTModernizeApp
+
+
+def modernize(script):
+    """
+    Convert a script from classic to modern mode.
+
+    Parameters
+    ----------
+    script : str
+        Classic mode script.
+
+    Returns
+    -------
+    str
+        Script converted to modern mode.
+
+    """
+    app = GMTModernizeApp(['bla', 'meh', 'foo'])
+    return '\n'.join(app.modernize(script.split('\n')[:-1]))

--- a/gmtmodernize/conversion.py
+++ b/gmtmodernize/conversion.py
@@ -3,8 +3,11 @@ Functions to convert a classic script into a modern one.
 
 The main functionality is exposed through the ``modernize`` function.
 """
+import os
+import sys
+import shutil
+import re
 
-from .cli import GMTModernizeApp
 
 
 def modernize(script):
@@ -24,3 +27,191 @@ def modernize(script):
     """
     app = GMTModernizeApp(['bla', 'meh', 'foo'])
     return '\n'.join(app.modernize(script.split('\n')[:-1]))
+
+
+def warn(*args, **kwargs):
+    """
+    Print message to stderr.
+    """
+    print(file=sys.stderr, *args, **kwargs)
+
+
+class GMTModernizeApp():
+    """
+    The application class.
+    """
+
+    # List of GMT modules that generate Postscript output
+    PS_MODULES = """
+    gmtlogo
+    grdcontour
+    grdimage
+    grdvector
+    grdview
+    psbasemap
+    psclip
+    pscoast
+    pscontour
+    pshistogram
+    psimage
+    pslegend
+    psmask
+    psrose
+    psscale
+    pssolar
+    pstext
+    pswiggle
+    psxyz
+    psxy
+    pscoupe
+    psmeca
+    pspolar
+    pssac
+    psvelo
+    mgd77track
+    pssegyz
+    pssegy
+    """.split()
+
+    def __init__(self, args, verbose=False, output_type='ps'):
+        self.verbose = verbose
+        assert output_type in ['pdf', 'ps']
+        self.output_type = output_type
+        assert len(args) >= 3, \
+            'Too few arguments. Provide input dir and output dir'
+        self.input_dir = os.path.normpath(args[1])
+        self.output_dir = os.path.normpath(args[2])
+        if '--quite' in args or '-q' in args:
+            self.verbose = False
+        else:
+            self.verbose = True
+
+    def info(self, *args, **kwargs):
+        """
+        Print message to stderr according to set verbosity.
+        """
+        if self.verbose:
+            print(file=sys.stderr, *args, **kwargs)
+
+    def modernize(self, script):
+        """
+        Given a GMT shell script (as a string), modernize it and return the new
+        text.
+        """
+        modern = []
+        ps_name = None
+        if self.output_type == 'ps':
+            args = '-Tp'
+        elif self.output_type == 'pdf':
+            args = '-Tf -P -A'
+        psconvert = '\ngmt psconvert {} -F$ps\n'.format(args)
+
+        # Copy the header comments and add a command to set the mode
+        # to modern after the header
+        for line in script:
+            line = line.strip()
+            if not line or line[0] != '#':
+                break
+            modern.append(line)
+        last_line = len(modern)
+        modern.append('gmt set GMT_RUNMODE modern')
+
+        # Parse the rest of the script
+        for line in script[last_line:]:
+            line = line.strip()
+
+            # Check if this line defines a .ps file name variable
+            ps_var_def = re.findall(r'^ps=.+\.ps$', line)
+            if ps_var_def:
+                assert len(ps_var_def) == 1, \
+                    "Found more than 1 ps variable in line '{}'".format(line)
+                ps_definition = ps_var_def[0]
+                ps_file_name = ps_definition.split('=')[1]
+                ps_name = os.path.splitext(ps_file_name)[0]
+                line = os.path.splitext(ps_definition)[0]
+
+            # Check if redirecting to the $ps variable and strip it out
+            redirect_to_ps = re.findall(r'.+>+ *\$ps(?: +|$)', line)
+            if redirect_to_ps:
+                assert len(redirect_to_ps) == 1, \
+                    "Found more than 1 ps redirection in line '{}'".format(
+                        line)
+                redirection = re.findall(r'>+ *\$ps(?: +|$)', line)[0]
+                line = line.replace(redirection, '').strip()
+
+            # Remove -O -K -R -J
+            okrj = re.findall(r'(?:(?<= )|^)-[KORJ](?: +|$)', line)
+            if okrj:
+                for match in okrj:
+                    line = line.replace(match, '')
+                line = line.strip()
+
+            modern.append(line)
+
+            # Check if line is deleting gmt.conf. Need to insert the psconvert
+            # before that.
+
+        # Only add a psconvert call if this script defined a ps variable
+        if ps_name is not None:
+            rm_gmt_conf = [i for i, line in enumerate(modern)
+                           if re.findall('(?:(?<= )|^)rm .* gmt.conf(?: +|$)',
+                                         line)]
+            assert len(rm_gmt_conf) <= 1, "Found more than 1 'rm gmt.conf'"
+            if rm_gmt_conf:
+                modern.insert(rm_gmt_conf[0], psconvert)
+                modern.append('')  # Make sure the file ends in a newline
+            else:
+                modern.append(psconvert)
+
+        return modern
+
+    def convert_script(self, old_script, modern_script):
+        """
+        Convert a script file in the old style to the modern style.
+
+        Reads in 'old_script', modernize it, and save the output to
+        'modern_scrip'.
+        """
+        self.info('  Converting:', old_script, ' --> ', modern_script)
+        with open(old_script) as infile:
+            old_content = infile.readlines()
+        modern_content = self.modernize(old_content)
+        with open(modern_script, 'w') as outfile:
+            outfile.write('\n'.join(modern_content))
+
+    def crawl_and_modernize(self, input_dir, output_dir):
+        """
+        Crawl the input dir and copy/modernize the contents to output dir.
+
+        Will copy any file that isn't a shell script (ends in .sh).
+        """
+
+        for base, _, files in os.walk(input_dir):
+            self.info('Base dir:', base)
+            base_output = base.replace(input_dir, output_dir)
+            os.mkdir(base_output)
+
+            scripts = set(f for f in files if os.path.splitext(f)[-1] == '.sh')
+            not_scripts = set(files).difference(scripts)
+
+            for file in not_scripts:
+                shutil.copy(os.path.join(base, file), base_output)
+
+            for script in scripts:
+                modern_script = os.path.join(base_output, script)
+                old_script = os.path.join(base, script)
+                self.convert_script(old_script, modern_script)
+
+    def main(self):
+        """
+        Execute the app to convert the scripts.
+        """
+
+        if os.path.exists(self.output_dir):
+            warn("Aborting: Output directory '{}' already exists.".format(
+                self.output_dir))
+            return 1
+
+        self.crawl_and_modernize(self.input_dir, self.output_dir)
+
+        return 0

--- a/gmtmodernize/tests/test_integration.py
+++ b/gmtmodernize/tests/test_integration.py
@@ -4,7 +4,7 @@ Test that the library converts a set of test scripts correctly.
 import os
 import pytest
 
-from ..cli import GMTModernizeApp
+from .. import modernize
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -19,7 +19,7 @@ def load_test_scripts(path):
     for fname in os.listdir(path):
         if os.path.splitext(fname)[-1] == '.sh' and fname[0] != '~':
             with open(os.path.join(path, fname)) as script:
-                scripts[fname] = script.readlines()
+                scripts[fname] = script.read()
     return scripts
 
 
@@ -43,9 +43,8 @@ def test_integration(classic, modern):
     'Compare converted scripts to a reference of what they should be.'
     assert set(classic.keys()) == set(modern.keys()), \
         'Different number of scripts in classic and modern data dirs'
-    app = GMTModernizeApp(['bla', 'meh', 'foo'])
     for script in classic:
-        modernized = app.modernize(classic[script])
-        assert '\n'.join(modernized) == ''.join(modern[script]), \
-            'Failed {}. Modernized:\n\n{}\n\n'.format(script,
-                                                      '\n'.join(modernized))
+        modernized = modernize(classic[script])
+        assert modernized == modern[script], \
+            'Failed {}.\n\nModernized:\n\n{}\n\nClassic:\n\n{}\n\n'.format(
+                script, modernized, classic[script])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ ENTRY_POINTS = {
 # DEPENDENCIES
 # #############################################################################
 INSTALL_REQUIRES = [
-    # 'docopt',
+    'docopt',
     # 'tqdm',
 ]
 


### PR DESCRIPTION
Refactor the code into a `gmtmodernize.modernize` function that 
converts a single script and a docopt powered CLI that uses it.
Will enable splitting the `modernize` function into more testable
parts later.

The CLI now converts a single script and prints results to stdout
by default. Optionally use `--recursive` and give two folders to 
have the old behavior (convert an entire folder).