### PR TITLE
Adapt script to new "gmt begin" syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,34 +31,36 @@ in the background.
 
 For example, the following classic mode script::
 
+    ps=map.ps
     gmt grdgradient -Nt0.2 -A45 data.nc -Gintens.nc
     gmt makecpt -Cgeo -T-8000/2000 > t.cpt
-    gmt grdimage -Ct.cpt -Iintens.nc data.nc -JM6i -P -K > classic_map.ps
-    gmt pscoast -Rdata.nc -J -O -Dh -Baf -W0.75p -K >> classic_map.ps
-    echo "Japan Trench" | gmt pstext -F+f32p+cTC -Dj0/0.2i -Gwhite -R -J -O -K >> classic_map.ps
-    gmt psxy -W2p lines.txt -R -J -O -K >> classic_map.ps
-    gmt psscale -R -J -O -DjBL+w3i/0.1i+h+o0.3i/0.4i -Ct.cpt -W0.001 -F+gwhite+p0.5p -Bxaf -By+l"km" >> classic_map.ps
-    gmt psconvert -Tf -P -A -Z classic_map.ps
+    gmt grdimage -Ct.cpt -Iintens.nc data.nc -JM6i -P -K > $ps
+    gmt pscoast -Rdata.nc -J -O -Dh -Baf -W0.75p -K >> $ps
+    echo "Japan Trench" | gmt pstext -F+f32p+cTC -Dj0/0.2i -Gwhite -R -J -O -K >> $ps
+    gmt psxy -W2p lines.txt -R -J -O -K >> $ps
+    gmt psscale -R -J -O -DjBL+w3i/0.1i+h+o0.3i/0.4i -Ct.cpt -W0.001 -F+gwhite+p0.5p -Bxaf -By+l"km" >> $ps
 
 is equivalent to the following in modern mode::
 
-    gmt begin
+    ps=map
+
+    gmt begin $ps ps
+
     gmt grdgradient -Nt0.2 -A45 data.nc -Gintens.nc
     gmt makecpt -Cgeo -T-8000/2000 > t.cpt
     gmt grdimage -Ct.cpt -Iintens.nc data.nc -JM6i -P
-    gmt pscoast -Dh -Baf -W0.75p
+    gmt pscoast -Rdata.nc -Dh -Baf -W0.75p
     echo "Japan Trench" | gmt pstext -F+f32p+cTC -Dj0/0.2i -Gwhite
     gmt psxy -W2p lines.txt
     gmt psscale -DjBL+w3i/0.1i+h+o0.3i/0.4i -Ct.cpt -W0.001 -F+gwhite+p0.5p -Bxaf -By+l"km"
-    gmt psconvert -Tf -P -A -Fmodern_map
+    rm -f intens.nc t.cpt
+
     gmt end
 
 See the scripts and data in the ``example`` folder.
 
-Read more about modern mode at:
-
-* `Version 2.0 of the modern mode spec <http://gmt.soest.hawaii.edu/boards/2/topics/5138>`__
-* `Initial proposal <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__
+Read more about modern mode at the
+`Modernization wiki page <http://gmt.soest.hawaii.edu/projects/gmt/wiki/Modernization>`__.
 
 
 Installing

--- a/example/modern.sh
+++ b/example/modern.sh
@@ -2,7 +2,11 @@
 # Modern mode: GMT commands avoids -R -J (when it can) and -O -K
 # Redirection to a PS file is done in the background.
 # Commands can guess -R from the input data or previous commands.
-gmt begin
+
+ps=map
+
+gmt begin $ps ps
+
 gmt grdgradient -Nt0.2 -A45 data.nc -Gintens.nc
 gmt makecpt -Cgeo -T-8000/2000 > t.cpt
 gmt grdimage -Ct.cpt -Iintens.nc data.nc -JM6i -P
@@ -12,5 +16,4 @@ gmt psxy -W2p lines.txt
 gmt psscale -DjBL+w3i/0.1i+h+o0.3i/0.4i -Ct.cpt -W0.001 -F+gwhite+p0.5p -Bxaf -By+l"km"
 rm -f intens.nc t.cpt
 
-gmt psconvert -Tp -Fmap
 gmt end

--- a/gmtmodernize/tests/data/modern/grdcontour.sh
+++ b/gmtmodernize/tests/data/modern/grdcontour.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
 #	$Id: grdcontour.sh 12114 2013-09-03 19:19:00Z fwobbe $
-gmt begin
 
 ps=grdcontour
+
+gmt begin $ps ps
 
 contour="gmt grdcontour -A200 -C100 -Gd4 xz-temp.nc -Jx0.4c/0.4c -Ba5f1 -BWNse -Wathin,grey -Wcdefault,grey"
 $contour -R-100/-60/3/21.02 -P -Y1.5c
@@ -19,5 +20,4 @@ echo 800 A >> cont.dat
 echo 900 C >> cont.dat
 gmt grdcontour -Ccont.dat xz-temp.nc -Jx -R-100/-60/3/20 -Ba5f1 -BWNse -Gd4 -Wathin,grey -Wcdefault,grey -Y9c
 
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/plot_symbols.sh
+++ b/gmtmodernize/tests/data/modern/plot_symbols.sh
@@ -2,9 +2,10 @@
 #	$Id: plot_symbols.sh 17436 2017-01-13 00:22:07Z pwessel $
 #
 # Plot all the symbols on a 1x1 inch grid pattern
-gmt begin
 
 ps=plot_symbols
+
+gmt begin $ps ps
 
 gmt psxy -R0/4/1/6 -Jx1i -P -Bg1 -Gred -W0.25p -S1i -X2i -Y2i << EOF
 > Fat pen -W2p
@@ -40,6 +41,4 @@ gmt psxy -R0/4/1/6 -Jx1i -P -Bg1 -Gred -W0.25p -S1i -X2i -Y2i << EOF
 3.5	1.5	a
 EOF
 
-
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/polcontr.sh
+++ b/gmtmodernize/tests/data/modern/polcontr.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Test based on issue # 968.  This one uses -JP6ir and fails.
-gmt begin
+
 ps=polcontr
+
+gmt begin $ps ps
+
 gmt grd2xyz -s "${src:-.}"/test.dat.nc > t.txt
 gmt psxy -R"${src:-.}"/test.dat.nc -JP6ir t.txt -Sc0.05c -By30 -Bx30 -BWSnE -C"${src:-.}"/test.dat.cpt -P
 gmt grdcontour "${src:-.}"/test.dat.nc -C"${src:-.}"/test.dat.cpt -A- -W+1p -By30 -Bx30 -BWSnE -Y4i
 
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/pscoast_JE3.sh
+++ b/gmtmodernize/tests/data/modern/pscoast_JE3.sh
@@ -2,11 +2,11 @@
 #
 #	$Id: pscoast_JE3.sh 13203 2014-05-27 02:55:31Z pwessel $
 # Test a non-global -JE plot
-gmt begin
 
 ps=pscoast_JE3
 
+gmt begin $ps ps
+
 gmt pscoast -B10g10 -Je-70/-90/1:15000000 -R-95/-60/-75/-55 -Di -Ggreen -Sblue -P
 
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/pscoast_JM.sh
+++ b/gmtmodernize/tests/data/modern/pscoast_JM.sh
@@ -2,11 +2,11 @@
 #
 #	$Id: pscoast_JM.sh 11490 2013-05-16 06:26:21Z pwessel $
 # Make sure when fixed it works for all resolutions -D?
-gmt begin
 
 ps=pscoast_JM
 
+gmt begin $ps ps
+
 gmt pscoast -R90/290/-70/65 -JM6i -P -Ggray -Baf
 
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/vector.sh
+++ b/gmtmodernize/tests/data/modern/vector.sh
@@ -2,9 +2,10 @@
 #       $Id: vector.sh 13579 2014-10-02 20:35:47Z pwessel $
 #
 # Check vector symbols
-gmt begin
 
 ps=vector
+
+gmt begin $ps ps
 
 gmt psbasemap -R0/6/0/3 -Jx1i -P -B1g1 -BWSne -Xc
 gmt gmtset MAP_VECTOR_SHAPE 0.5
@@ -66,6 +67,4 @@ gmt psxy -W1p -S << EOF
 5.9	2.8	60	1i	V0.2i+je+er
 EOF
 
-
-gmt psconvert -Tp -F$ps
 gmt end

--- a/gmtmodernize/tests/data/modern/wedges.sh
+++ b/gmtmodernize/tests/data/modern/wedges.sh
@@ -2,9 +2,11 @@
 #       $Id: wedges.sh 16367 2016-05-05 01:55:00Z pwessel $
 #
 # Check wedges and geowedges
-gmt begin
 
 ps=wedges
+
+gmt begin $ps ps
+
 gmt gmtset PROJ_ELLIPSOID Sphere
 
 # Cartesian
@@ -27,5 +29,4 @@ echo -50 -30 50 110  | gmt psxy -SW30d+r -W2p
 echo -10 80 -60 240  | gmt psxy -SW20d -W2p -Gyellow
 gmt psxy -T
 
-gmt psconvert -Tp -F$ps
 gmt end


### PR DESCRIPTION
No longer need `psconvert` in the end of the scripts.