### PR TITLE
Fix failure for non-plot scripts

### DIFF
--- a/gmtmodernize/conversion.py
+++ b/gmtmodernize/conversion.py
@@ -61,13 +61,14 @@ def modernize(script):
     # Copy the header comments and add a command to set the mode
     # to modern after the header
     for line in script:
-        line = line.strip()
+        line = line.rstrip()
         if not line or line[0] != '#':
             break
         modern.append(line)
     last_line = len(modern)
 
     # Look for the "ps" variable definition and extract the name
+    ps_var_line = None
     for l, line in enumerate(script[last_line:]):
         line = line.strip()
         # Check if this line defines a .ps file name variable
@@ -81,15 +82,19 @@ def modernize(script):
             modern.append(line)
             ps_var_line = last_line + l
             break
-    script.pop(ps_var_line)
+    if ps_var_line is not None:
+        script.pop(ps_var_line)
+        begin_args = " $ps ps"
+    else:
+        begin_args = ""
 
     modern.append('')
-    modern.append('gmt begin $ps ps')
+    modern.append('gmt begin{}'.format(begin_args))
     modern.append('')
 
     # Parse the rest of the script
     for line in script[last_line:]:
-        line = line.strip()
+        line = line.rstrip()
 
         # Check if redirecting to the $ps variable and strip it out
         redirect_to_ps = re.findall(r'.+>+ *\$ps(?: +|$)', line)

--- a/gmtmodernize/tests/data/classic/bswap16.sh
+++ b/gmtmodernize/tests/data/classic/bswap16.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# $Id: bswap16.sh 11490 2013-05-16 06:26:21Z pwessel $
+
+# test byteswapping 16 bit integers
+
+# generate random binary file
+BYTES=$((1024*1024)) # 1 MiB
+head -c $BYTES /dev/urandom > data.b
+
+# swap
+gmt gmtconvert -bi1H -bo1Hw data.b | gmt gmtconvert -bi1Hw -bo1H > out.u
+gmt gmtconvert -bi1h -bo1hw data.b | gmt gmtconvert -bi1hw -bo1h > out.d
+
+# compare result
+diff -q data.b out.u
+diff -q data.b out.d
+
+# swap using gmt xyz2grd
+gmt xyz2grd -Sswapped_tmp.b -ZH data.b
+gmt xyz2grd -Sswapped.b -ZH swapped_tmp.b
+
+# compare result
+diff -q data.b swapped.b
+
+# files must differ
+if diff -q swapped_tmp.b swapped.b; then
+  false # return with error
+fi

--- a/gmtmodernize/tests/data/modern/bswap16.sh
+++ b/gmtmodernize/tests/data/modern/bswap16.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# $Id: bswap16.sh 11490 2013-05-16 06:26:21Z pwessel $
+
+gmt begin
+
+# test byteswapping 16 bit integers
+
+# generate random binary file
+BYTES=$((1024*1024)) # 1 MiB
+head -c $BYTES /dev/urandom > data.b
+
+# swap
+gmt gmtconvert -bi1H -bo1Hw data.b | gmt gmtconvert -bi1Hw -bo1H > out.u
+gmt gmtconvert -bi1h -bo1hw data.b | gmt gmtconvert -bi1hw -bo1h > out.d
+
+# compare result
+diff -q data.b out.u
+diff -q data.b out.d
+
+# swap using gmt xyz2grd
+gmt xyz2grd -Sswapped_tmp.b -ZH data.b
+gmt xyz2grd -Sswapped.b -ZH swapped_tmp.b
+
+# compare result
+diff -q data.b swapped.b
+
+# files must differ
+if diff -q swapped_tmp.b swapped.b; then
+  false # return with error
+fi
+
+gmt end


### PR DESCRIPTION
Need to consider scripts that don't define a 'ps' variable. These should
get a plain 'gmt begin' with no arguments. Add a test case for this.

Also remove only trailing white space to avoid removing identation from
scripts.