### PR TITLE
Tell TravisCI to build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ notifications:
 branches:
     only:
         - master
+        # Regex to build tagged commits with version numbers
+        - /\d+\.\d+(\.\d+)?(-\S*)?$/
 
 language: python
 


### PR DESCRIPTION
For some reason, restricting builds to master also restricts tags.
Add a regex to build tags that are version numbers.