### PR TITLE
Remove stray "gmt psxy -T" from modernized scripts

### DIFF
--- a/gmtmodernize/conversion.py
+++ b/gmtmodernize/conversion.py
@@ -112,6 +112,11 @@ def modernize(script):
                 line = line.replace(match, '')
             line = line.strip()
 
+        # Remove stray "psxy -T" used to end the postscript plots
+        stray_psxy = re.findall(r'psxy -T(?: +|$)', line)
+        if stray_psxy:
+            line = ""
+
         modern.append(line)
 
     modern.append('')

--- a/gmtmodernize/tests/data/classic/arrows.sh
+++ b/gmtmodernize/tests/data/classic/arrows.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+ps=arrows.ps
+xr=`gmt math -Q 1 15 COSD MUL 1.5 ADD =`
+xri=`gmt math -Q 1 15 COSD MUL 1.5 SUB =`
+xl=`gmt math -Q $xr NEG =`
+xli=`gmt math -Q $xri NEG =`
+gmt psbasemap -R-3/3/0/9 -Jx1i -P -Baf -K -Xc > $ps
+gmt psxy -R -J -O -K -W0.5p << EOF >> $ps
+> -W0.5p
+-1.5	0
+-1.5	9
+>
+1.5	0
+1.5	9
+> -W0.5p,-
+$xl	0
+$xl	9
+>
+$xr	0
+$xr	9
+>
+$xli	0
+$xli	9
+>
+$xri	0
+$xri	9
+EOF
+echo 0 8.8 0 3i | gmt psxy -R -J -O -K -Sv1i+jc+h0.5 -W6p --PS_MITER_LIMIT=0 >> $ps
+echo 0 8.2 0 3i | gmt psxy -R -J -O -K -Sv1i+ea+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 7.6 0 3i | gmt psxy -R -J -O -K -Sv1i+ba+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 7.0 0 3i | gmt psxy -R -J -O -K -Sv1i+ea+bi+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 6.4 0 3i | gmt psxy -R -J -O -K -Sv1i+ba+ei+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 5.8 0 3i | gmt psxy -R -J -O -K -Sv1i+eA+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 5.2 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 4.6 0 3i | gmt psxy -R -J -O -K -Sv1i+eA+bI+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 4.0 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+eI+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0 >> $ps
+echo 0 3.4 0 3i | gmt psxy -R -J -O -K -Sv1i+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+echo 0 2.8 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+echo 0 2.2 0 3i | gmt psxy -R -J -O -K -Sv1i+eA+bI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+echo 0 1.6 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+echo 0 1.0 0 3i | gmt psxy -R -J -O -K -Sv1i+bI+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+echo 0 0.4 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
+gmt psxy -R -J -O -T >> $ps

--- a/gmtmodernize/tests/data/classic/logos.sh
+++ b/gmtmodernize/tests/data/classic/logos.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#	$Id: logos.sh 16562 2016-06-18 04:04:08Z pwessel $
+# Testing gmt logo options
+
+ps=logos.ps
+
+gmt psxy -R0/8.5/0/11 -Jx1i -X0 -Y0 -P -K -W4p << EOF > $ps
+> vertical line
+4.25	0.2
+4.25	10.8
+> top horizontal line
+0.2	8.25
+8.3	8.25
+> middle horizontal line
+0.2	5.5
+8.3	5.5
+> bottom horizontal line
+0.2	2.75
+8.3	2.75
+EOF
+# Logo on yellow background with outline and with gray shadow
+gmt logo -Dx0/0+w3.5i -O -K -F+p+glightyellow+s -Y0.5i -X0.375i >> $ps
+# Logo on yellow background with outline and with darkred shadow
+gmt logo -Dx0/0+w3.5i -O -K -F+p+glightyellow+sdarkred -X4.25i >> $ps
+# Logo on yellow background with outline and larger south clearance
+gmt logo -Dx0/0+w3.5i -O -K -F+p+glightyellow+c4p/4p/20p/4p -Y2.75i -X-4.25i >> $ps
+# Logo on no background with double outline and unequal clearances
+gmt logo -Dx0/0+w3.5i -O -K -F+p+c12p/6p/20p/4p+i -X4.25i >> $ps
+# Logo on yellow background with outline
+gmt logo -Dx0/0+w3.5i -O -K -F+p+glightyellow -Y2.75i -X-4.25i >> $ps
+# Logo on yellow background without outline
+gmt logo -Dx0/0+w3.5i -O -K -F+glightyellow -X4.25i >> $ps
+# Logo by itself
+gmt logo -Dx0/0+w3.5i -O -K -Y2.75i -X-4.25i >> $ps
+# Logo with outline
+gmt logo -Dx0/0+w3.5i -O -K -F -X4.25i >> $ps
+gmt psxy -R -J -O -T >> $ps

--- a/gmtmodernize/tests/data/modern/arrows.sh
+++ b/gmtmodernize/tests/data/modern/arrows.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+ps=arrows
+
+gmt begin $ps ps
+
+xr=`gmt math -Q 1 15 COSD MUL 1.5 ADD =`
+xri=`gmt math -Q 1 15 COSD MUL 1.5 SUB =`
+xl=`gmt math -Q $xr NEG =`
+xli=`gmt math -Q $xri NEG =`
+gmt psbasemap -R-3/3/0/9 -Jx1i -P -Baf -Xc
+gmt psxy -W0.5p << EOF
+> -W0.5p
+-1.5	0
+-1.5	9
+>
+1.5	0
+1.5	9
+> -W0.5p,-
+$xl	0
+$xl	9
+>
+$xr	0
+$xr	9
+>
+$xli	0
+$xli	9
+>
+$xri	0
+$xri	9
+EOF
+echo 0 8.8 0 3i | gmt psxy -Sv1i+jc+h0.5 -W6p --PS_MITER_LIMIT=0
+echo 0 8.2 0 3i | gmt psxy -Sv1i+ea+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 7.6 0 3i | gmt psxy -Sv1i+ba+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 7.0 0 3i | gmt psxy -Sv1i+ea+bi+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 6.4 0 3i | gmt psxy -Sv1i+ba+ei+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 5.8 0 3i | gmt psxy -Sv1i+eA+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 5.2 0 3i | gmt psxy -Sv1i+bA+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 4.6 0 3i | gmt psxy -Sv1i+eA+bI+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 4.0 0 3i | gmt psxy -Sv1i+bA+eI+jc+h0.5 -W6p -Gred --PS_MITER_LIMIT=0
+echo 0 3.4 0 3i | gmt psxy -Sv1i+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+echo 0 2.8 0 3i | gmt psxy -Sv1i+bA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+echo 0 2.2 0 3i | gmt psxy -Sv1i+eA+bI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+echo 0 1.6 0 3i | gmt psxy -Sv1i+bA+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+echo 0 1.0 0 3i | gmt psxy -Sv1i+bI+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+echo 0 0.4 0 3i | gmt psxy -Sv1i+bA+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round
+
+gmt end

--- a/gmtmodernize/tests/data/modern/logos.sh
+++ b/gmtmodernize/tests/data/modern/logos.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#	$Id: logos.sh 16562 2016-06-18 04:04:08Z pwessel $
+# Testing gmt logo options
+
+ps=logos
+
+gmt begin $ps ps
+
+gmt psxy -R0/8.5/0/11 -Jx1i -X0 -Y0 -P -W4p << EOF
+> vertical line
+4.25	0.2
+4.25	10.8
+> top horizontal line
+0.2	8.25
+8.3	8.25
+> middle horizontal line
+0.2	5.5
+8.3	5.5
+> bottom horizontal line
+0.2	2.75
+8.3	2.75
+EOF
+# Logo on yellow background with outline and with gray shadow
+gmt logo -Dx0/0+w3.5i -F+p+glightyellow+s -Y0.5i -X0.375i
+# Logo on yellow background with outline and with darkred shadow
+gmt logo -Dx0/0+w3.5i -F+p+glightyellow+sdarkred -X4.25i
+# Logo on yellow background with outline and larger south clearance
+gmt logo -Dx0/0+w3.5i -F+p+glightyellow+c4p/4p/20p/4p -Y2.75i -X-4.25i
+# Logo on no background with double outline and unequal clearances
+gmt logo -Dx0/0+w3.5i -F+p+c12p/6p/20p/4p+i -X4.25i
+# Logo on yellow background with outline
+gmt logo -Dx0/0+w3.5i -F+p+glightyellow -Y2.75i -X-4.25i
+# Logo on yellow background without outline
+gmt logo -Dx0/0+w3.5i -F+glightyellow -X4.25i
+# Logo by itself
+gmt logo -Dx0/0+w3.5i -Y2.75i -X-4.25i
+# Logo with outline
+gmt logo -Dx0/0+w3.5i -F -X4.25i
+
+gmt end

--- a/gmtmodernize/tests/data/modern/wedges.sh
+++ b/gmtmodernize/tests/data/modern/wedges.sh
@@ -27,6 +27,5 @@ echo 50 -30 -50 -110  | gmt psxy -SW30d+a -W2p
 echo -50 -30 50 110  | gmt psxy -SW30d -Gorange
 echo -50 -30 50 110  | gmt psxy -SW30d+r -W2p
 echo -10 80 -60 240  | gmt psxy -SW20d -W2p -Gyellow
-gmt psxy -T
 
 gmt end


### PR DESCRIPTION
It was used to finish the layer cake but this is done by gmt end now.